### PR TITLE
Escape HTML in post titles

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 gem 'aws-sdk-dynamodb', '~> 1.126'
 gem 'aws-sdk-ses', '~> 1.76'
 gem 'http', '~> 5.2'
+gem 'nokogiri', '~> 1.16', '>= 1.16.7' # Peer requirement of aws-sdk
 
 group :development do
   gem 'pry-byebug', '~> 3.10'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -43,6 +43,10 @@ GEM
       ffi-compiler (~> 1.0)
       rake (~> 13.0)
     method_source (1.0.0)
+    mini_portile2 (2.8.7)
+    nokogiri (1.16.7)
+      mini_portile2 (~> 2.8.2)
+      racc (~> 1.4)
     parallel (1.26.3)
     parser (3.3.5.1)
       ast (~> 2.4.1)
@@ -80,6 +84,7 @@ DEPENDENCIES
   aws-sdk-dynamodb (~> 1.126)
   aws-sdk-ses (~> 1.76)
   http (~> 5.2)
+  nokogiri (~> 1.16, >= 1.16.7)
   pry-byebug (~> 3.10)
   rubocop (~> 1.68)
 

--- a/lib/digest_renderer.rb
+++ b/lib/digest_renderer.rb
@@ -8,7 +8,7 @@ class DigestRenderer
     <br>
     <% for @post in @posts %>
       <p>
-        <%= @post['title'] %>
+        <%= ERB::Escape.html_escape(@post['title']) %>
         <br>
         <%= @post['points'] %> points -
         <% if @post['url'] %>

--- a/test_mailer.rb
+++ b/test_mailer.rb
@@ -4,7 +4,7 @@ require_relative 'lib/digest_mailer'
 require_relative 'lib/digest_renderer'
 require_relative 'lib/storage_adapter'
 
-date = Time.gm(2020, 5, 2)
+date = Time.gm(2024, 10, 26)
 
 sa = StorageAdapter.new
 digest = sa.fetch_digest(type: 'TOP_N#10', date:)
@@ -14,5 +14,5 @@ renderer = DigestRenderer.new(posts:, date:)
 mailer = DigestMailer.new(ses_client: Aws::SES::Client.new(region: 'us-west-2'))
 mailer.send_mail(
   renderer:,
-  recipients: ['test1@samshadwell.com', 'test2@samshadwell.com']
+  recipients: ['hi@samshadwell.com']
 )


### PR DESCRIPTION
Tested locally on the October 26 digest, which included a link to this post: https://news.ycombinator.com/item?id=41948666