### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 


### PR DESCRIPTION
Potential fix for [https://github.com/samshadwell/HNDigest/security/code-scanning/2](https://github.com/samshadwell/HNDigest/security/code-scanning/2)

In general, the fix is to explicitly declare a `permissions` block in the workflow so the `GITHUB_TOKEN` has only the minimal scopes required. For this CI workflow, all steps only need to read repository contents (for checkout and running local tools); they do not need to write to the repo or manage issues/PRs. The best fix is to add a root-level `permissions` block with `contents: read`, which will apply to all jobs (`build` and `opentofu`) since neither currently overrides permissions. This keeps existing behavior while constraining token privileges.

Concretely, in `.github/workflows/ci.yml`, insert a new root-level `permissions:` section after the `on:` block (e.g., after line 7 and before `env:`). The block should be:

```yaml
permissions:
  contents: read
```

No additional imports or dependencies are needed; this is purely a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
