### PR TITLE
Allow manual trigger of OpenTofu

### DIFF
--- a/.github/workflows/opentofu-deploy.yml
+++ b/.github/workflows/opentofu-deploy.yml
@@ -6,12 +6,12 @@ on:
     branches: [main]
     paths:
       - "infrastructure/**"
-      - ".github/workflows/cd.yml"
+      - ".github/workflows/opentofu-deploy.yml"
   pull_request:
     branches: [main]
     paths:
       - "infrastructure/**"
-      - ".github/workflows/cd.yml"
+      - ".github/workflows/opentofu-deploy.yml"
 
 # On main: only one workflow at a time (queue, don't cancel)
 # On PRs: each PR runs independently

--- a/.github/workflows/opentofu-deploy.yml
+++ b/.github/workflows/opentofu-deploy.yml
@@ -1,6 +1,7 @@
 name: OpenTofu Deploy
 
 on:
+  workflow_dispatch:
   push:
     branches: [main]
     paths:


### PR DESCRIPTION
Sometimes I make a change entirely within Github Actions variables. In that case, there are no code changes and I just need to manually kick off the `tofu apply`