### PR TITLE
Remove explicit return path

### DIFF
--- a/src/digest_mailer.rs
+++ b/src/digest_mailer.rs
@@ -42,7 +42,6 @@ impl DigestMailer {
             .source(&self.from_address)
             .destination(dest)
             .reply_to_addresses(&self.reply_to_address)
-            .return_path(&self.reply_to_address)
             .message(message)
             .send()
             .await


### PR DESCRIPTION
Remove the explicit return path of the message, and allow SES set to the (correct) default.

This was an issue revealed by my sender change to `mail@hndigest.samshadwell.com`. AWS is already configured to use `mail.hndigest.samshadwell.com` as the MAIL FROM, so I should stick with that default.