### PR TITLE
Fail program if many emails fail to send

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -176,13 +176,8 @@ async fn handler(_event: LambdaEvent<Value>) -> Result<(), Error> {
         }
     }
 
-    if failure_count * 10 > success_count + failure_count {
-        error!(
-            failure_count,
-            total_emails = success_count + failure_count,
-            "More than 10% of emails failed to send"
-        );
-        Err(Error::from("Large number of email send failures"))
+    if failure_count > 0 {
+        Err(Error::from("Some emails failed to send."))
     } else {
         info!("Handler completed successfully.");
         Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -176,8 +176,17 @@ async fn handler(_event: LambdaEvent<Value>) -> Result<(), Error> {
         }
     }
 
-    info!("Handler completed successfully.");
-    Ok(())
+    if failure_count * 10 > success_count + failure_count {
+        error!(
+            failure_count,
+            total_emails = success_count + failure_count,
+            "More than 10% of emails failed to send"
+        );
+        Err(Error::from("Large number of email send failures"))
+    } else {
+        info!("Handler completed successfully.");
+        Ok(())
+    }
 }
 
 /// Build digests for all strategies in parallel.


### PR DESCRIPTION
Previously the lambda would exit successfully, even if all the emails within it failed to send.

Because I don't expect these API calls to spuriously fail (they're already being retried by the SDK), any failure here likely reveals some kind of logical error. As such, I will fail the entire lambda run if I get a failure.

I may change this as I get more information, but for now this is what I'll do.