### PR TITLE
Use separate Cloudfront ingress for prod/staging

### DIFF
--- a/infrastructure/github_oidc.tf
+++ b/infrastructure/github_oidc.tf
@@ -168,10 +168,10 @@ resource "aws_iam_role_policy" "github_actions_infra" {
         Sid    = "LandingPageCloudFront"
         Effect = "Allow"
         Action = "cloudfront:*"
-        Resource = [
-          aws_cloudfront_distribution.landing_page.arn,
-          aws_cloudfront_origin_access_control.landing_page.arn
-        ]
+        Resource = concat(
+          [for k, _ in local.environments : aws_cloudfront_distribution.landing_page[k].arn],
+          [aws_cloudfront_origin_access_control.landing_page.arn]
+        )
       },
       {
         Sid    = "APIGateway"

--- a/infrastructure/lambda.tf
+++ b/infrastructure/lambda.tf
@@ -32,7 +32,7 @@ resource "aws_lambda_function" "hndigest" {
         EMAIL_FROM     = each.value.from_email
         EMAIL_REPLY_TO = each.value.reply_to_email
         RUN_HOUR_UTC   = tostring(var.run_hour_utc)
-        BASE_URL       = "https://${var.landing_page_domain}"
+        BASE_URL       = "https://${each.value.domain}"
       },
       each.value.subject_prefix != "" ? { SUBJECT_PREFIX = each.value.subject_prefix } : {}
     )
@@ -68,7 +68,7 @@ resource "aws_lambda_function" "hndigest_api" {
     variables = {
       RUST_LOG       = "info"
       DYNAMODB_TABLE = each.value.table_name
-      BASE_URL       = "https://${var.landing_page_domain}"
+      BASE_URL       = "https://${each.value.domain}"
     }
   }
 

--- a/infrastructure/locals.tf
+++ b/infrastructure/locals.tf
@@ -18,6 +18,7 @@ locals {
         subject_prefix = ""
         # Prod gets the EventBridge schedule
         has_schedule = true
+        domain       = var.landing_page_domain
       }
     },
     local.create_staging ? {
@@ -31,6 +32,7 @@ locals {
         subject_prefix = "[STAGING]"
         # Staging is triggered manually, no schedule
         has_schedule = false
+        domain       = var.landing_page_staging_domain
       }
     } : {}
   )

--- a/infrastructure/outputs.tf
+++ b/infrastructure/outputs.tf
@@ -48,12 +48,22 @@ output "staging_dynamodb_table_name" {
 # Landing page outputs
 output "landing_page_cloudfront_domain" {
   description = "CloudFront distribution domain name for the landing page"
-  value       = aws_cloudfront_distribution.landing_page.domain_name
+  value       = aws_cloudfront_distribution.landing_page["prod"].domain_name
 }
 
 output "landing_page_cloudfront_hosted_zone_id" {
   description = "CloudFront distribution hosted zone ID (for Route53 alias records)"
-  value       = aws_cloudfront_distribution.landing_page.hosted_zone_id
+  value       = aws_cloudfront_distribution.landing_page["prod"].hosted_zone_id
+}
+
+output "staging_landing_page_cloudfront_domain" {
+  description = "CloudFront distribution domain name for staging"
+  value       = local.create_staging ? aws_cloudfront_distribution.landing_page["staging"].domain_name : null
+}
+
+output "staging_landing_page_cloudfront_hosted_zone_id" {
+  description = "CloudFront distribution hosted zone ID for staging (for Route53 alias records)"
+  value       = local.create_staging ? aws_cloudfront_distribution.landing_page["staging"].hosted_zone_id : null
 }
 
 output "landing_page_s3_bucket" {


### PR DESCRIPTION
My previous setup of one Cloudfront for both doesn't work once we have to differentiate the lambdas backing the relevant /api/ paths.