### PR TITLE
Improve cache hits on deploy jobs

### DIFF
--- a/.github/actions/build-lambda/action.yml
+++ b/.github/actions/build-lambda/action.yml
@@ -17,6 +17,9 @@ runs:
 
     - name: Rust Cache
       uses: Swatinem/rust-cache@v2.8.2
+      with:
+        # Avoid collisions with non-musl builds
+        key: "lambda-musl"
 
     - name: Build release binary
       shell: bash


### PR DESCRIPTION
Previously these were getting cache hits from non-musl builds, meaning deploys would always recompile everything, even with cache hits.