### PR TITLE
Always run OpenTofu plan in CI

### DIFF
--- a/.github/workflows/opentofu-deploy.yml
+++ b/.github/workflows/opentofu-deploy.yml
@@ -4,14 +4,8 @@ on:
   workflow_dispatch:
   push:
     branches: [main]
-    paths:
-      - "infrastructure/**"
-      - ".github/workflows/opentofu-deploy.yml"
   pull_request:
     branches: [main]
-    paths:
-      - "infrastructure/**"
-      - ".github/workflows/opentofu-deploy.yml"
 
 # On main: only one workflow at a time (queue, don't cancel)
 # On PRs: each PR runs independently


### PR DESCRIPTION
Because OpenTofu references another dir (static files uploaded to S3) the selection logic here is no longer correct.

Rather than try and keep this up-to-date, I'll opt to always run this check since it's pretty quick anyway