### PR TITLE
Fix SSM parameter reads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -202,9 +202,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-dynamodb"
-version = "1.102.0"
+version = "1.103.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5f7e6a53cf5ee8b7041c73106d9a93480b47f8b955466262b043aab0b5bf489"
+checksum = "6df2a8b03419775bfaf4f3ebbb65a9772e9e69eed4467a1b33f22226722340fb"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -228,6 +228,29 @@ name = "aws-sdk-sesv2"
 version = "1.111.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "779d5c35e02584d8ab4dc91ea0ab9bec0a1405e1bd21d0ae8cd52a7aa6996ce9"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-observability",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-ssm"
+version = "1.102.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20b44877ff0d7c31dbcc3bb89088164cc62839f53c95f70235a265551c8f3efa"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -1093,6 +1116,7 @@ dependencies = [
  "aws-config",
  "aws-sdk-dynamodb",
  "aws-sdk-sesv2",
+ "aws-sdk-ssm",
  "chrono",
  "email_address",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,9 +22,10 @@ path = "src/bin/add_subscriber.rs"
 anyhow = "1.0"
 email_address = "0.2"
 askama = "0.15"
-aws-config = { version = "1.1.7", features = ["rustls"] }
-aws-sdk-dynamodb = "1.16.0"
-aws-sdk-sesv2 = "1.14.0"
+aws-config = { version = "1.8.12", features = ["rustls"] }
+aws-sdk-dynamodb = "1.103.0"
+aws-sdk-sesv2 = "1.111.0"
+aws-sdk-ssm = "1.102.0"
 chrono = { version = "0.4", features = ["serde"] }
 futures = "0.3"
 lambda_http = "1.0.2"

--- a/infrastructure/lambda.tf
+++ b/infrastructure/lambda.tf
@@ -65,18 +65,15 @@ resource "aws_lambda_function" "hndigest_api" {
   memory_size = var.lambda_memory_size
   timeout     = var.lambda_timeout
 
-  layers = [var.params_secrets_extension_arn]
-
   environment {
     variables = {
-      AWS_LAMBDA_LOG_FORMAT                  = "json"
-      RUST_LOG                               = "info"
-      PARAMETERS_SECRETS_EXTENSION_LOG_LEVEL = "info"
-      DYNAMODB_TABLE                         = each.value.table_name
-      BASE_URL                               = "https://${each.value.domain}"
-      EMAIL_FROM                             = each.value.from_email
-      EMAIL_REPLY_TO                         = each.value.reply_to_email
-      TURNSTILE_SECRET_KEY_PARAM             = aws_ssm_parameter.turnstile_secret_key[each.key].name
+      AWS_LAMBDA_LOG_FORMAT      = "json"
+      RUST_LOG                   = "info"
+      DYNAMODB_TABLE             = each.value.table_name
+      BASE_URL                   = "https://${each.value.domain}"
+      EMAIL_FROM                 = each.value.from_email
+      EMAIL_REPLY_TO             = each.value.reply_to_email
+      TURNSTILE_SECRET_KEY_PARAM = aws_ssm_parameter.turnstile_secret_key[each.key].name
     }
   }
 

--- a/infrastructure/lambda.tf
+++ b/infrastructure/lambda.tf
@@ -27,12 +27,13 @@ resource "aws_lambda_function" "hndigest" {
   environment {
     variables = merge(
       {
-        RUST_LOG       = "info"
-        DYNAMODB_TABLE = each.value.table_name
-        EMAIL_FROM     = each.value.from_email
-        EMAIL_REPLY_TO = each.value.reply_to_email
-        RUN_HOUR_UTC   = tostring(var.run_hour_utc)
-        BASE_URL       = "https://${each.value.domain}"
+        AWS_LAMBDA_LOG_FORMAT = "json"
+        RUST_LOG              = "info"
+        DYNAMODB_TABLE        = each.value.table_name
+        EMAIL_FROM            = each.value.from_email
+        EMAIL_REPLY_TO        = each.value.reply_to_email
+        RUN_HOUR_UTC          = tostring(var.run_hour_utc)
+        BASE_URL              = "https://${each.value.domain}"
       },
       each.value.subject_prefix != "" ? { SUBJECT_PREFIX = each.value.subject_prefix } : {}
     )
@@ -68,13 +69,14 @@ resource "aws_lambda_function" "hndigest_api" {
 
   environment {
     variables = {
+      AWS_LAMBDA_LOG_FORMAT                  = "json"
       RUST_LOG                               = "info"
+      PARAMETERS_SECRETS_EXTENSION_LOG_LEVEL = "info"
       DYNAMODB_TABLE                         = each.value.table_name
       BASE_URL                               = "https://${each.value.domain}"
       EMAIL_FROM                             = each.value.from_email
       EMAIL_REPLY_TO                         = each.value.reply_to_email
       TURNSTILE_SECRET_KEY_PARAM             = aws_ssm_parameter.turnstile_secret_key[each.key].name
-      PARAMETERS_SECRETS_EXTENSION_LOG_LEVEL = "warn"
     }
   }
 

--- a/infrastructure/lambda.tf
+++ b/infrastructure/lambda.tf
@@ -71,7 +71,7 @@ resource "aws_lambda_function" "hndigest_api" {
     variables = {
       AWS_LAMBDA_LOG_FORMAT                  = "json"
       RUST_LOG                               = "info"
-      PARAMETERS_SECRETS_EXTENSION_LOG_LEVEL = "debug"
+      PARAMETERS_SECRETS_EXTENSION_LOG_LEVEL = "info"
       DYNAMODB_TABLE                         = each.value.table_name
       BASE_URL                               = "https://${each.value.domain}"
       EMAIL_FROM                             = each.value.from_email

--- a/infrastructure/lambda.tf
+++ b/infrastructure/lambda.tf
@@ -71,7 +71,7 @@ resource "aws_lambda_function" "hndigest_api" {
     variables = {
       AWS_LAMBDA_LOG_FORMAT                  = "json"
       RUST_LOG                               = "info"
-      PARAMETERS_SECRETS_EXTENSION_LOG_LEVEL = "info"
+      PARAMETERS_SECRETS_EXTENSION_LOG_LEVEL = "debug"
       DYNAMODB_TABLE                         = each.value.table_name
       BASE_URL                               = "https://${each.value.domain}"
       EMAIL_FROM                             = each.value.from_email

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -76,13 +76,6 @@ variable "turnstile_site_key" {
   default     = "0x4AAAAAACTuSJcLuENs4joL"
 }
 
-variable "params_secrets_extension_arn" {
-  description = "Full ARN of the AWS Parameters and Secrets Lambda Extension layer (region- and architecture-specific)"
-  type        = string
-  # This is for us-west-2, x86. See: https://docs.aws.amazon.com/systems-manager/latest/userguide/ps-integration-lambda-extensions.html#ps-integration-lambda-extensions-add
-  default = "arn:aws:lambda:us-west-2:345057560386:layer:AWS-Parameters-and-Secrets-Lambda-Extension:24"
-}
-
 ###
 # Hosting config
 ###

--- a/src/bin/api.rs
+++ b/src/bin/api.rs
@@ -312,11 +312,10 @@ async fn fetch_ssm_parameter(
     parameter_name: &str,
 ) -> Result<String, Box<dyn std::error::Error>> {
     let session_token = env::var("AWS_SESSION_TOKEN")?;
+    let params = [("name", parameter_name), ("withDecryption", "true")];
     let response: SsmExtensionResponse = http_client
-        .get(format!(
-            "http://localhost:2773/systemsmanager/parameters/get?name={}&withDecryption=true",
-            urlencoding::encode(parameter_name)
-        ))
+        .get("http://localhost:2773/systemsmanager/parameters/get")
+        .query(&params)
         .header("X-Aws-Parameters-Secrets-Token", &session_token)
         .send()
         .await?


### PR DESCRIPTION
This param reading was failing. Turns out you can't call the SSM layer until you're in your handler.

So instead of that approach I'll use the SSM SDK in my startup. It might be slightly less optimal, but I don't think it'll matter. This also simplifies my Lambda setup to not depend on another thing.