### PR TITLE
Fix SNS event schema

### DIFF
--- a/infrastructure/iam.tf
+++ b/infrastructure/iam.tf
@@ -56,6 +56,25 @@ resource "aws_iam_role_policy" "dynamodb_access" {
   })
 }
 
+# SQS DLQ access for bounce handler
+resource "aws_iam_role_policy" "sqs_dlq_access" {
+  for_each = local.environments
+
+  name = "${lower(var.project_name)}${each.value.name_suffix}-sqs-dlq-access"
+  role = aws_iam_role.lambda_exec[each.key].id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect   = "Allow"
+        Action   = "sqs:SendMessage"
+        Resource = aws_sqs_queue.bounce_handler_dlq[each.key].arn
+      }
+    ]
+  })
+}
+
 # SSM Parameter Store access (for secrets)
 resource "aws_iam_role_policy" "ssm_access" {
   for_each = local.environments

--- a/infrastructure/lambda.tf
+++ b/infrastructure/lambda.tf
@@ -103,6 +103,10 @@ resource "aws_lambda_function" "bounce_handler" {
   memory_size = var.lambda_memory_size
   timeout     = var.lambda_timeout
 
+  dead_letter_config {
+    target_arn = aws_sqs_queue.bounce_handler_dlq[each.key].arn
+  }
+
   environment {
     variables = {
       AWS_LAMBDA_LOG_FORMAT = "json"

--- a/infrastructure/sqs.tf
+++ b/infrastructure/sqs.tf
@@ -1,0 +1,8 @@
+# Dead-letter queue for bounce handler Lambda
+# Failed events land here for manual inspection
+resource "aws_sqs_queue" "bounce_handler_dlq" {
+  for_each = local.environments
+
+  name                      = "${lower(var.project_name)}${each.value.name_suffix}-bounce-handler-dlq"
+  message_retention_seconds = 1209600 # 14 days
+}

--- a/src/bin/bounce_handler.rs
+++ b/src/bin/bounce_handler.rs
@@ -21,7 +21,7 @@ use tracing::{info, warn};
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 struct SesNotification {
-    notification_type: String,
+    event_type: String,
     bounce: Option<BounceNotification>,
     complaint: Option<ComplaintNotification>,
 }
@@ -82,7 +82,7 @@ async fn handler(
     for record in &event.payload.records {
         let notification = &record.sns.message;
 
-        match notification.notification_type.as_str() {
+        match notification.event_type.as_str() {
             "Bounce" => {
                 let bounce = notification
                     .bounce


### PR DESCRIPTION
From the [AWS page](https://docs.aws.amazon.com/ses/latest/dg/notification-contents.html) on this schema:
> If you [set up event publishing](https://docs.aws.amazon.com/ses/latest/dg/monitor-sending-using-event-publishing-setup.html), this field is named eventType.

That's what I get for not reading that closely, I guess

Also creates an SQS dead letter queue so I can inspect/manually triage failed events in the future