### PR TITLE
Add undeliverable notifications to DLQ

### DIFF
--- a/infrastructure/sns.tf
+++ b/infrastructure/sns.tf
@@ -36,4 +36,8 @@ resource "aws_sns_topic_subscription" "bounce_handler" {
   topic_arn = aws_sns_topic.ses_notifications[each.key].arn
   protocol  = "lambda"
   endpoint  = aws_lambda_function.bounce_handler[each.key].arn
+
+  redrive_policy = jsonencode({
+    deadLetterTargetArn = aws_sqs_queue.bounce_handler_dlq[each.key].arn
+  })
 }

--- a/infrastructure/sqs.tf
+++ b/infrastructure/sqs.tf
@@ -6,3 +6,27 @@ resource "aws_sqs_queue" "bounce_handler_dlq" {
   name                      = "${lower(var.project_name)}${each.value.name_suffix}-bounce-handler-dlq"
   message_retention_seconds = 1209600 # 14 days
 }
+
+# Allow SNS to send undeliverable messages to the DLQ
+resource "aws_sqs_queue_policy" "bounce_handler_dlq" {
+  for_each = local.environments
+
+  queue_url = aws_sqs_queue.bounce_handler_dlq[each.key].id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect    = "Allow"
+        Principal = { Service = "sns.amazonaws.com" }
+        Action    = "sqs:SendMessage"
+        Resource  = aws_sqs_queue.bounce_handler_dlq[each.key].arn
+        Condition = {
+          ArnEquals = {
+            "aws:SourceArn" = aws_sns_topic.ses_notifications[each.key].arn
+          }
+        }
+      }
+    ]
+  })
+}


### PR DESCRIPTION
In a previous PR (#82) I added a DLQ for Lambda. This was so that any items the Lambda eventually failed to process would end up on the DLQ.

However, there's another failure mode that isn't covered yet, which is if the SNS -> Lambda handoff fails. In that case we also want SNS to write directly to the DLQ. That's what this PR does