### PR TITLE
Widen deadman window

### DIFF
--- a/infrastructure/alerts.tf
+++ b/infrastructure/alerts.tf
@@ -89,7 +89,7 @@ resource "aws_cloudwatch_metric_alarm" "digest_not_invoked" {
   evaluation_periods  = 1
   metric_name         = "Invocations"
   namespace           = "AWS/Lambda"
-  period              = 86400
+  period              = 90000 # 25 hours (in case scheduling drifts)
   statistic           = "Sum"
   threshold           = 1
   treat_missing_data  = "breaching"


### PR DESCRIPTION
In case the email executions happen slightly more than 24 hours apart, don't want a noisy alarm. Honestly 24 hours + 5 minutes would have likely been fine, but this works too