### PR TITLE
Fix CD pipeline

### DIFF
--- a/.github/workflows/promote-to-prod.yml
+++ b/.github/workflows/promote-to-prod.yml
@@ -231,7 +231,7 @@ jobs:
   prod-infra-apply:
     name: "Infra Apply (production)"
     needs: [approve-prod, prod-infra-plan]
-    if: needs.prod-infra-plan.outputs.has_changes == 'true'
+    if: ${{ !cancelled() && !failure() && needs.prod-infra-plan.outputs.has_changes == 'true' }}
     runs-on: ubuntu-latest
     defaults:
       run:


### PR DESCRIPTION
Observed an issue in which an empty _staging_ plan forced the prod apply to get skipped (see https://github.com/samshadwell/HNDigest/actions/runs/22286335411). This is because the "skipped" status cascaded to the `prod-infra-apply` step and skipped it.

Added the necessary !failed() && !cancelled()