### PR TITLE
Move to managed cache/origin policies

### DIFF
--- a/infrastructure/bootstrap/github_oidc.tf
+++ b/infrastructure/bootstrap/github_oidc.tf
@@ -177,7 +177,9 @@ resource "aws_iam_role_policy" "github_actions_infra" {
         Action = "cloudfront:*"
         Resource = [
           "arn:aws:cloudfront::${data.aws_caller_identity.current.account_id}:distribution/*",
-          "arn:aws:cloudfront::${data.aws_caller_identity.current.account_id}:origin-access-control/*"
+          "arn:aws:cloudfront::${data.aws_caller_identity.current.account_id}:origin-access-control/*",
+          "arn:aws:cloudfront::${data.aws_caller_identity.current.account_id}:cache-policy/*",
+          "arn:aws:cloudfront::${data.aws_caller_identity.current.account_id}:origin-request-policy/*"
         ]
       },
       {

--- a/infrastructure/environments/production/main.tf
+++ b/infrastructure/environments/production/main.tf
@@ -48,6 +48,7 @@ module "web" {
 
   environment              = "prod"
   name_suffix              = ""
+  cloudfront_web_acl_arn   = var.cloudfront_web_acl_arn
   domain                   = var.domain
   landing_page_bucket_name = var.landing_page_bucket_name
   turnstile_site_key       = var.turnstile_site_key

--- a/infrastructure/environments/production/variables.tf
+++ b/infrastructure/environments/production/variables.tf
@@ -50,6 +50,12 @@ variable "run_hour_utc" {
   default     = 5
 }
 
+variable "cloudfront_web_acl_arn" {
+  description = "ARN of the WAF Web ACL created by AWS when enabling CloudFront flat-rate pricing"
+  type        = string
+  default     = "arn:aws:wafv2:us-east-1:087108798373:global/webacl/CreatedByCloudFront-114a103d/52137a35-f978-4dde-b7eb-2a1eaa1c0fd5"
+}
+
 variable "lambda_memory_size" {
   description = "Memory size for Lambda functions in MB"
   type        = number

--- a/infrastructure/environments/staging/main.tf
+++ b/infrastructure/environments/staging/main.tf
@@ -47,6 +47,7 @@ module "web" {
 
   environment              = "staging"
   name_suffix              = "-staging"
+  cloudfront_web_acl_arn   = var.cloudfront_web_acl_arn
   domain                   = var.domain
   landing_page_bucket_name = var.landing_page_bucket_name
   turnstile_site_key       = var.turnstile_site_key

--- a/infrastructure/environments/staging/variables.tf
+++ b/infrastructure/environments/staging/variables.tf
@@ -38,6 +38,12 @@ variable "turnstile_site_key" {
   default     = "0x4AAAAAACTuSJcLuENs4joL"
 }
 
+variable "cloudfront_web_acl_arn" {
+  description = "ARN of the WAF Web ACL created by AWS when enabling CloudFront flat-rate pricing"
+  type        = string
+  default     = "arn:aws:wafv2:us-east-1:087108798373:global/webacl/CreatedByCloudFront-0cf3e787/f5bd2664-3404-4168-ab68-9f9096a7a065"
+}
+
 variable "lambda_memory_size" {
   description = "Memory size for Lambda functions in MB"
   type        = number

--- a/infrastructure/modules/web/landing_page.tf
+++ b/infrastructure/modules/web/landing_page.tf
@@ -57,12 +57,15 @@ data "aws_cloudfront_origin_request_policy" "all_viewer_except_host_header" {
 }
 
 # CloudFront distribution
+# NOTE: This uses flat-rate billing with a free tier. This cannot be configured
+# in OpenTofu yet, see https://github.com/hashicorp/terraform-provider-aws/issues/45450
 resource "aws_cloudfront_distribution" "landing_page" {
   enabled             = true
   is_ipv6_enabled     = true
   default_root_object = "index.html"
   aliases             = [var.domain]
-  price_class         = "PriceClass_100" # US, Canada, Europe only (cheapest)
+  price_class         = "PriceClass_All"
+  web_acl_id          = var.cloudfront_web_acl_arn
 
   # S3 origin for static content
   origin {

--- a/infrastructure/modules/web/variables.tf
+++ b/infrastructure/modules/web/variables.tf
@@ -30,6 +30,12 @@ variable "turnstile_site_key" {
   type        = string
 }
 
+variable "cloudfront_web_acl_arn" {
+  description = "ARN of the WAF Web ACL for CloudFront, created by AWS when enabling flat-rate pricing. Leave null if not using flat-rate pricing."
+  type        = string
+  default     = null
+}
+
 variable "static_files_path" {
   description = "Path to the static files directory"
   type        = string


### PR DESCRIPTION
Migrate Cloudfront caching and origing request policies to AWS-managed ones.

Custom policies are deprecated, these are semantically what I want. This is all in service of letting me sign up for the free pricing tier