### PR TITLE
Add default values for emails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,9 +58,6 @@ jobs:
   tofu-plan-staging:
     name: "OpenTofu Plan (staging)"
     runs-on: ubuntu-latest
-    env:
-      TF_VAR_ses_from_email: ${{ vars.SES_FROM_EMAIL }}
-      TF_VAR_ses_reply_to_email: ${{ vars.SES_REPLY_TO_EMAIL }}
     outputs:
       has_changes: ${{ steps.plan.outputs.has_changes }}
     steps:
@@ -94,9 +91,6 @@ jobs:
   tofu-plan-production:
     name: "OpenTofu Plan (production)"
     runs-on: ubuntu-latest
-    env:
-      TF_VAR_ses_from_email: ${{ vars.SES_FROM_EMAIL }}
-      TF_VAR_ses_reply_to_email: ${{ vars.SES_REPLY_TO_EMAIL }}
     outputs:
       has_changes: ${{ steps.plan.outputs.has_changes }}
     steps:

--- a/.github/workflows/promote-to-prod.yml
+++ b/.github/workflows/promote-to-prod.yml
@@ -20,8 +20,6 @@ env:
   AWS_REGION: us-west-2
   STAGING_FUNCTION: HNDigest-staging
   PROD_FUNCTION: HNDigest
-  TF_VAR_ses_from_email: ${{ vars.SES_FROM_EMAIL }}
-  TF_VAR_ses_reply_to_email: ${{ vars.SES_REPLY_TO_EMAIL }}
 
 jobs:
   echo-inputs:

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -19,8 +19,6 @@ concurrency:
 env:
   AWS_REGION: us-west-2
   LAMBDA_FUNCTION_NAME: HNDigest-staging
-  TF_VAR_ses_from_email: ${{ vars.SES_FROM_EMAIL }}
-  TF_VAR_ses_reply_to_email: ${{ vars.SES_REPLY_TO_EMAIL }}
 
 jobs:
   echo-inputs:

--- a/infrastructure/environments/production/variables.tf
+++ b/infrastructure/environments/production/variables.tf
@@ -13,11 +13,13 @@ variable "aws_region" {
 variable "ses_from_email" {
   description = "Email address to send digests from"
   type        = string
+  default     = "mail@hndigest.samshadwell.com"
 }
 
 variable "ses_reply_to_email" {
   description = "Reply-to email address"
   type        = string
+  default     = "hi@samshadwell.com"
 }
 
 variable "domain" {

--- a/infrastructure/environments/staging/variables.tf
+++ b/infrastructure/environments/staging/variables.tf
@@ -13,11 +13,13 @@ variable "aws_region" {
 variable "ses_from_email" {
   description = "Email address to send digests from"
   type        = string
+  default     = "mail@hndigest.samshadwell.com"
 }
 
 variable "ses_reply_to_email" {
   description = "Reply-to email address"
   type        = string
+  default     = "hi@samshadwell.com"
 }
 
 variable "domain" {


### PR DESCRIPTION
Before these were stored in tfvars/github actions variables. But they're not really secrets (and are publicly on hndigest.samshadwell.com), so there's no real reason to keep them out of defaults.

Following the pattern I've established elsewhere, defaults here are "my" values for everything