### PR TITLE
Fix Dependabot OpenTofu directories

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,7 +20,10 @@ updates:
         patterns:
           - "*"
   - package-ecosystem: "opentofu"
-    directory: "/infrastructure"
+    directories:
+      - "/infrastructure/bootstrap"
+      - "/infrastructure/environments/staging"
+      - "/infrastructure/environments/production"
     schedule:
       interval: "monthly"
     groups:


### PR DESCRIPTION
Dependabot config needs to point to the directories which contain the `.terraform.lock.hcl` files